### PR TITLE
Feature/09042026 change historigram performance

### DIFF
--- a/.github/workflows/issues_histogram.yml
+++ b/.github/workflows/issues_histogram.yml
@@ -26,28 +26,45 @@ jobs:
         with:
           python-version: "3.11"
 
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install requests matplotlib python-decouple
+        run: python -m pip install --upgrade pip && pip install matplotlib>=3.7.3 ## comment
 
-      - name: Run issues histogram script
+      - name: Run script
         working-directory: ./IshikawaTools
-        env:
-          HISTOGRAM_TOKEN: ${{ secrets.HISTOGRAM_TOKEN }}
-        run: python ./histogram.py
 
-      - name: Commit and Push changes
-        run: |
-          # Configurar el usuario de Git (puedes usar el bot de GitHub)
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          
-          # Añadir el archivo generado
-          git add IshikawaTools/issues_per_week.png
-          
-          # Hacer el commit solo si hay cambios
-          git commit -m "Update issues histogram graph [skip ci]" || echo "No changes to commit"
-          
-          # Subir los cambios al repositorio
-          git push
+        run: git pull && python ./histogram.py
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ishikawa-chart
+          path: IshikawaTools/issues_per_week.png
+
+
+
+#      - name: Install dependencies
+#        run: |
+#          python -m pip install --upgrade pip
+#          pip install requests matplotlib python-decouple
+#
+#      - name: Run issues histogram script
+#        working-directory: ./IshikawaTools
+#        env:
+#          HISTOGRAM_TOKEN: ${{ secrets.HISTOGRAM_TOKEN }}
+#        run: python ./histogram.py
+#
+#      - name: Commit and Push changes
+#        run: |
+#          # Configurar el usuario de Git (puedes usar el bot de GitHub)
+#          git config --global user.name "github-actions[bot]"
+#          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+#
+#          # Añadir el archivo generado
+#          git add IshikawaTools/issues_per_week.png
+#
+#          # Hacer el commit solo si hay cambios
+#          git commit -m "Update issues histogram graph [skip ci]" || echo "No changes to commit"
+#
+#          # Subir los cambios al repositorio
+#          git push

--- a/.github/workflows/issues_histogram.yml
+++ b/.github/workflows/issues_histogram.yml
@@ -28,7 +28,7 @@ jobs:
 
 
       - name: Install dependencies
-        run: python -m pip install --upgrade pip && pip install matplotlib>=3.7.3 ## comment
+        run: python -m pip install --upgrade pip && pip install matplotlib>=3.7.3 && pip install python-decouple ## comment
 
       - name: Run script
         working-directory: ./IshikawaTools

--- a/.github/workflows/issues_histogram.yml
+++ b/.github/workflows/issues_histogram.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Run script
         working-directory: ./IshikawaTools
+        env:
+           HISTOGRAM_TOKEN: ${{ secrets.HISTOGRAM_TOKEN }}
 
         run: git pull && python ./histogram.py
 

--- a/.github/workflows/issues_histogram.yml
+++ b/.github/workflows/issues_histogram.yml
@@ -28,7 +28,7 @@ jobs:
 
 
       - name: Install dependencies
-        run: python -m pip install --upgrade pip && pip install matplotlib>=3.7.3 && pip install python-decouple ## comment
+        run: python -m pip install --upgrade pip && pip install matplotlib>=3.7.3 && pip install requests matplotlib python-decouple # comment
 
       - name: Run script
         working-directory: ./IshikawaTools


### PR DESCRIPTION
## 🐛 Fix: store histograms as artifacts instead of pushing via GitHub Actions

### Description
Currently, generated histograms are being committed and pushed to the repository through a GitHub Action. This is not appropriate, as it pollutes the commit history and is not the recommended way to handle temporary outputs.

### Problem

- Unnecessary automated commits are created
- Repository history becomes noisy
- CI/CD best practices are not followed

### Proposed Solution
Update the workflow to store histograms as artifacts using `actions/upload-artifact` instead of committing them to the repository.

Tasks

 - Remove commit/push logic from the workflow
 - Add step to upload histograms as artifacts
 - Verify artifacts can be downloaded from GitHub Actions
 - Update documentation if needed

Acceptance Criteria

- Histograms are no longer committed to the repository
- They are available in the workflow artifacts section
- The workflow runs successfully without regressions