### PR TITLE
[BUG]: the redirection to the list page is not working correctly

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -486,11 +486,6 @@ def delete_review(request, ressenya_id):
 
 @login_required
 def lists(request):
-    pass
-
-
-@cap_manager_permes
-def llistes(request):
     return render(request, 'llistes.html', {
         'carpetes': request.user.les_meves_carpetes.all(),
         'elements_solts': LlistaPersonal.objects.filter(usuari=request.user, carpeta__isnull=True)


### PR DESCRIPTION
his fixes a runtime error on /llistes/ that raised a Django ValueError:
The view users.views.lists didn't return an HttpResponse object. It returned None instead.
Root cause: the lists view was defined with pass, so it returned None.
Changes made
• Updated users/views.py so lists(request) now renders llistes.html.
• Kept the expected template context:
◦ carpetes: authenticated user folders.
◦ elements_solts: list items without a folder (carpeta__isnull=True).
Result
•/llistes/ now returns a valid HTTP response.
•The page no longer crashes at runtime.