### PR TITLE
44 feature add another kind of valoration

### DIFF
--- a/apps/contents/views.py
+++ b/apps/contents/views.py
@@ -10,6 +10,7 @@ from apps.contents.services import get_all_series, get_all_movies, get_directors
 from apps.lists.models import LlistaPersonal
 from apps.reviews.models import Ressenya
 from apps.users.decorators.permissions import cap_manager_permes
+from django.db.models import Avg
 
 # Create your views here.
 
@@ -69,6 +70,13 @@ def content_detail(request, tipus, content_id):
             pelicula=movie_db
         ).first()
 
+    ## community reviews
+    community_rating = Ressenya.objects.filter(
+        pelicula=movie_db
+    ).aggregate(avg=Avg('puntuacio'))['avg'] or 0
+    community_rating = round(community_rating, 1)
+
+
     return render(request, 'pagina_contingut.html', {
         'item': item,
         'tipus': tipus,
@@ -78,6 +86,7 @@ def content_detail(request, tipus, content_id):
         'ressenyes': Ressenya.objects.filter(pelicula=movie_db).order_by('-data_publicacio'),
         'recomanacions': recommendations,
         'ressenya_usuari': ressenya_usuari,
+        'community_rating': community_rating,
     })
 
 @cap_manager_permes

--- a/apps/contents/views.py
+++ b/apps/contents/views.py
@@ -73,8 +73,10 @@ def content_detail(request, tipus, content_id):
     ## community reviews
     community_rating = Ressenya.objects.filter(
         pelicula=movie_db
-    ).aggregate(avg=Avg('puntuacio'))['avg'] or 0
-    community_rating = round(community_rating, 1)
+    ).aggregate(avg=Avg('puntuacio'))['avg']
+
+    if community_rating is not None:
+        community_rating = round(community_rating, 1)
 
 
     return render(request, 'pagina_contingut.html', {

--- a/templates/pagina_contingut.html
+++ b/templates/pagina_contingut.html
@@ -207,13 +207,28 @@
                 {% endif %}
             </div>
 
-            <div class="p-3 bg-white rounded-4 border d-inline-flex align-items-center gap-3 shadow-sm">
+            <div class="p-3 bg-white rounded-4 border d-inline-flex align-items-center gap-3 shadow-sm me-3">
                 <div class="d-flex align-items-center justify-content-center bg-warning rounded-3 px-3 py-2 fw-black fs-4">
                     <i class="bi bi-star-fill me-2"></i> {{ item.rating|default:"0.0" }}
                 </div>
+
                 <div>
-                    <div class="small fw-bold text-uppercase text-muted" style="font-size: 0.6rem;">Global Score</div>
-                    <div class="fw-bold text-dark">StreamSync Community</div>
+                    <div class="small fw-bold text-uppercase text-muted" style="font-size: 0.6rem;">
+                        Official Rating
+                    </div>
+                    <div class="fw-bold text-dark">Providers Score</div>
+                </div>
+            </div>
+            <div class="p-3 bg-white rounded-4 border d-inline-flex align-items-center gap-3 shadow-sm">
+                <div class="d-flex align-items-center justify-content-center bg-primary text-white rounded-3 px-3 py-2 fw-black fs-4">
+                    <i class="bi bi-people-fill me-2"></i> {{ community_rating }}
+                </div>
+
+                <div>
+                    <div class="small fw-bold text-uppercase text-muted" style="font-size: 0.6rem;">
+                        Community Rating
+                    </div>
+                    <div class="fw-bold text-dark">StreamSync Users</div>
                 </div>
             </div>
         </div>

--- a/templates/pagina_contingut.html
+++ b/templates/pagina_contingut.html
@@ -221,7 +221,11 @@
             </div>
             <div class="p-3 bg-white rounded-4 border d-inline-flex align-items-center gap-3 shadow-sm">
                 <div class="d-flex align-items-center justify-content-center bg-primary text-white rounded-3 px-3 py-2 fw-black fs-4">
-                    <i class="bi bi-people-fill me-2"></i> {{ community_rating }}
+                    <i class="bi bi-people-fill me-2"></i> {% if community_rating %}
+                        {{ community_rating }}
+                    {% else %}
+                        -
+                    {% endif %}
                 </div>
 
                 <div>


### PR DESCRIPTION
## Descritpion
This PR implements the feature that allows user opinions (reviews/ratings) to be displayed directly on the content detail page. Users can now see what others think about a movie or series 

## What's included
- Added a new component to render user opinions within the content detail view.
- UI adjustments to ensure opinions are visually consistent with the rest of the page.
- Added message "-" when no opinions are available.

## Why is this needed? 
Previously, user opinions were not visible from the content page, reducing engagement and making it harder for users to evaluate content based on community feedback.
This feature improves usability and encourages interaction.

## How to test
1. Navigate to any content detail page (movie/series).
2. Scroll to the new “User Opinions” section.
3. Verify that:
- Existing opinions load correctly.
- Ratings and comments match the backend data.
4.  Add a new opinion and confirm it appears immediately.
5. Check behavior when no opinions exist.